### PR TITLE
feat(android): changer l'application ID en com.subtrack.app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    namespace "com.zeqiri.subtrack"
+    namespace "com.subtrack.app"
     compileSdk rootProject.ext.compileSdkVersion
     buildToolsVersion "35.0.0"
     defaultConfig {
-        applicationId "com.zeqiri.subtrack"
+        applicationId "com.subtrack.app"
         minSdkVersion rootProject.ext.minSdkVersion 
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/release/output-metadata.json
+++ b/android/app/release/output-metadata.json
@@ -4,7 +4,7 @@
     "type": "APK",
     "kind": "Directory"
   },
-  "applicationId": "com.zeqiri.subtrack",
+  "applicationId": "com.subtrack.app",
   "variantName": "release",
   "elements": [
     {

--- a/android/app/src/main/java/com/subtrack/app/MainActivity.java
+++ b/android/app/src/main/java/com/subtrack/app/MainActivity.java
@@ -1,4 +1,4 @@
-package com.zeqiri.subtrack;
+package com.subtrack.app;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">SubTrack</string>
     <string name="title_activity_main">SubTrack</string>
-    <string name="package_name">com.zeqiri.subtrack</string>
-    <string name="custom_url_scheme">com.zeqiri.subtrack</string>
+    <string name="package_name">com.subtrack.app</string>
+    <string name="custom_url_scheme">com.subtrack.app</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,7 +1,7 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.zeqiri.subtrack',
+  appId: 'com.subtrack.app',
   appName: 'SubTrack',
   webDir: 'www',
   plugins: {


### PR DESCRIPTION
Remplace com.zeqiri.subtrack par com.subtrack.app dans tous les fichiers de configuration Android et Capacitor en préparation de la publication sur le Play Store.